### PR TITLE
Add optional neon-api-key secret to terraform CI/CD

### DIFF
--- a/.github/workflows/terraform-cd.yaml
+++ b/.github/workflows/terraform-cd.yaml
@@ -20,12 +20,19 @@ on:
         type: string
       aws-role:
         required: true
-        type: string  
+        type: string
+    secrets:
+      token:
+        required: false
+      neon-api-key:
+        required: false
 
 jobs:
   terraform-cd:
     name: terraform-cd
     runs-on: ubuntu-latest
+    env:
+      NEON_API_KEY: ${{ secrets.neon-api-key }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -20,12 +20,19 @@ on:
         type: string
       aws-role:
         required: true
-        type: string  
+        type: string
+    secrets:
+      token:
+        required: false
+      neon-api-key:
+        required: false
 
 jobs:
   terraform-ci:
     name: terraform-ci
     runs-on: ubuntu-latest
+    env:
+      NEON_API_KEY: ${{ secrets.neon-api-key }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Lets caller repos that provision Neon (via the `kislerdm/neon` provider) authenticate by forwarding `NEON_API_KEY` to terraform.

- Adds an optional `neon-api-key` secret to both `terraform-ci` and `terraform-cd`, injected as `NEON_API_KEY` at job level.
- Also declares the `token` secret that callers already pass — required now that a `secrets:` block exists, so existing callers don't break.
- Fully backward compatible: both secrets are optional; repos that don't use Neon are unaffected and behavior is unchanged.

After merge, tag `v1.1.0` so callers can reference it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)